### PR TITLE
Repair broken passphrase retry

### DIFF
--- a/irssi-xmpp/src/core/popenRWE.c
+++ b/irssi-xmpp/src/core/popenRWE.c
@@ -88,6 +88,8 @@ int pcloseRWE(int pid, int *rwepipe) {
 	close(rwepipe[0]);
 	close(rwepipe[1]);
 	close(rwepipe[2]);
-	rc = waitpid(pid, &status, 0);
+	do {
+		rc = waitpid(pid, &status, 0);
+	} while (rc != 0 && ! WIFEXITED(status));
 	return status;
 }

--- a/irssi-xmpp/src/core/tools.c
+++ b/irssi-xmpp/src/core/tools.c
@@ -23,6 +23,7 @@
 #include <stdio.h>
 
 #include <string.h>
+#include <sys/wait.h>
 
 #include "module.h"
 #include "recode.h"
@@ -36,8 +37,8 @@
 
 static const char *utf8_charset = "UTF-8";
 
-char *call_gpg(char *switches, char *input, char *input2, \
-               int get_stderr, int snip_data) {
+char *call_gpg_round(char *switches, char *input, char *input2, \
+               int get_stderr, int snip_data, unsigned round) {
 	int pipefd[2], rwepipe[3], childpid, tmp2_fd = 0, in_data = !snip_data;
 	FILE* cstream;
 	char *cmd, *tmp2_path = NULL, *output = NULL;
@@ -126,10 +127,15 @@ char *call_gpg(char *switches, char *input, char *input2, \
 		strcat(output, buf2);
 	}
 
-	if(pcloseRWE(childpid, rwepipe) == 512) { /* TODO: more check exit code */
+	// http://www.gnu-darwin.org/www001/src/ports/security/libgpg-error/work/libgpg-error-1.5/src/err-codes.h.in
+	// 11	GPG_ERR_BAD_PASSPHRASE		Bad passphrase
+	// 31	GPG_ERR_INV_PASSPHRASE		Invalid passphrase
+	int exit_status = WEXITSTATUS(pcloseRWE(childpid, rwepipe));
+	if(round > 0 && (exit_status == 11 || exit_status == 31)) {
 		g_free(pgp_passwd);
 		pgp_passwd = NULL;
-		output = call_gpg(switches, input, input2, get_stderr, snip_data);
+		output = call_gpg_round(switches, input, input2, get_stderr,
+					snip_data, round--);
 	}
 
 	if(tmp2_fd)   close(tmp2_fd);
@@ -140,6 +146,13 @@ char *call_gpg(char *switches, char *input, char *input2, \
 	return output;
 pgp_error:
 	return NULL;
+}
+
+
+char *call_gpg(char *switches, char *input, char *input2, \
+               int get_stderr, int snip_data, unsigned round) {
+	return call_gpg_round(switches, input, input2, get_stderr,
+			      snip_data, 3);
 }
 
 


### PR DESCRIPTION
The exit code handling of the gpg process to detect wrong passphrases
was a bit adventurous. It checked for the raw status value from waitpid
instead of the WEXITSTATUS() macro.
The code that handles the waitpid also does not check for any errors.
This is now fixed by evaluating the waitpid return value and the use of
the WEXITSTATUS() macro.

Signed-off-by: Jan Losinski <losinski@wh2.tu-dresden.de>